### PR TITLE
Update ParseRestClient.php to get rid of SSL Certificate error

### DIFF
--- a/parse/ParseRestClient.php
+++ b/parse/ParseRestClient.php
@@ -92,7 +92,10 @@ class ParseRestClient{
 			$urlParams = http_build_query($args['urlParams'], '', '&');
     		$url = $url.'?'.$urlParams;
 		}
-
+		
+		//telling php to ignore SSL certificate warning
+        	curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
+		
 		curl_setopt($c, CURLOPT_URL, $url);
 
 		$response = curl_exec($c);


### PR DESCRIPTION
Get rid of SSL Certificate error

Message: Trying to get property of non-object
Filename: parse/ParseRestClient.php
Fatal error: Uncaught ParseLibraryException: [0]: thrown in D:\xampp\htdocs\cilogin\parse\ParseRestClient.php on line 177

https://parse.com/questions/error-with-parse-php-library
